### PR TITLE
removing attributes prefix

### DIFF
--- a/addon/services/head-data.js
+++ b/addon/services/head-data.js
@@ -38,19 +38,13 @@ export default Service.extend({
    * This is the main content of your page, shown as the conten in the unfurled links
    */
   description: computed('routeName', function() {
-    const content = this.get('currentRouteModel.content');
+    const content = this.get('content');
 
     if (content && content.substring) {
       return `${content.substring(0, 260)}...`;
     }
 
-    return this.getWithDefault('currentRouteModel.attributes.description', emberMetaConfig.description);
-  }),
-  /**
-   * Internal - used by keywords & tags
-   */
-  categories: computed('routeName', function() {
-    return this.get('currentRouteModel.categories');
+    return this.getWithDefault('currentRouteModel.description', emberMetaConfig.description);
   }),
   /**
    * Used for twitter meta to display 'filed under'
@@ -113,9 +107,21 @@ export default Service.extend({
     return this.get('currentRouteModel.attributes.canonical');
   }),
   /**
+   * Internal - used by keywords & tags
+   */
+  categories: computed('routeName', function() {
+    return this.get('currentRouteModel.categories');
+  }),
+  /**
+   * Internal - optionally used for description
+   */
+  content: computed('routeName', function() {
+    return this.get('currentRouteModel.content');
+  }),
+  /**
    * Internal - used for url
    */
   slug: computed('routeName', function() {
     return this.get('currentRouteModel.slug');
-  }),
+  })
 });

--- a/addon/services/head-data.js
+++ b/addon/services/head-data.js
@@ -19,19 +19,19 @@ export default Service.extend({
    * Used for og:title, twitter:title as the title to show in the unfurled links
    */
   articleTitle: computed('routeName', function() {
-    return this.get('currentRouteModel.attributes.articleTitle');
+    return this.get('currentRouteModel.articleTitle');
   }),
   /**
    * Used for twitter 'written by' meta.
    */
   author: computed('routeName', function() {
-    return this.get('currentRouteModel.attributes.author');
+    return this.get('currentRouteModel.author');
   }),
   /**
    * Used for article:published_time
    */
   date: computed('routeName', function() {
-    return this.get('currentRouteModel.attributes.date');
+    return this.get('currentRouteModel.date');
   }),
   /**
    * Used for <meta name="description">, og:description, twitter:description
@@ -47,10 +47,10 @@ export default Service.extend({
     return this.getWithDefault('currentRouteModel.attributes.description', emberMetaConfig.description);
   }),
   /**
-   * Not used directly - used by keywords & tags
+   * Internal - used by keywords & tags
    */
   categories: computed('routeName', function() {
-    return this.get('currentRouteModel.attributes.categories');
+    return this.get('currentRouteModel.categories');
   }),
   /**
    * Used for twitter meta to display 'filed under'
@@ -63,13 +63,13 @@ export default Service.extend({
    * Used for og:image twitter:image:src, the image to display in your unfurled links
    */
   imgSrc: computed('routeName', function() {
-    return this.getWithDefault('currentRouteModel.attributes.imgSrc', emberMetaConfig.imgSrc);
+    return this.getWithDefault('currentRouteModel.imgSrc', emberMetaConfig.imgSrc);
   }),
   /**
    * Used for og:site_name
    */
   siteName: computed('routeName', function() {
-    return this.getWithDefault('currentRouteModel.attributes.siteName', emberMetaConfig.siteName);
+    return this.getWithDefault('currentRouteModel.siteName', emberMetaConfig.siteName);
   }),
   /**
    * Used for article:tag
@@ -81,26 +81,26 @@ export default Service.extend({
    * Used for <title>, og:title, twitter:title
    */
   title: computed('routeName', function() {
-    return this.getWithDefault('currentRouteModel.attributes.title', emberMetaConfig.title);
+    return this.getWithDefault('currentRouteModel.title', emberMetaConfig.title);
   }),
   /**
    * Used for twitter:site and twitter:creator
    */
   twitterUsername: computed('routeName', function() {
-    return this.getWithDefault('currentRouteModel.attributes.twitterUsername', emberMetaConfig.twitterUsername);
+    return this.getWithDefault('currentRouteModel.twitterUsername', emberMetaConfig.twitterUsername);
   }),
   /**
    * Used for og:type, defaults to 'website'
    */
   type: computed('routeName', function() {
-    return this.getWithDefault('currentRouteModel.attributes.type', 'website');
+    return this.getWithDefault('currentRouteModel.type', 'website');
   }),
   /**
    * Used for <link rel="canonical">, og:url, twitter:url
    */
   url: computed('routeName', function() {
-    let url = this.getWithDefault('currentRouteModel.attributes.url', emberMetaConfig.url);
-    const slug = this.get('currentRouteModel.attributes.slug');
+    let url = this.getWithDefault('currentRouteModel.url', emberMetaConfig.url);
+    const slug = this.get('slug');
     if (slug) {
       url = `${url}${slug}/`;
     }
@@ -111,5 +111,11 @@ export default Service.extend({
    */
   canonical: computed('routeName', function() {
     return this.get('currentRouteModel.attributes.canonical');
-  })
+  }),
+  /**
+   * Internal - used for url
+   */
+  slug: computed('routeName', function() {
+    return this.get('currentRouteModel.slug');
+  }),
 });

--- a/tests/dummy/app/routes/blog/post.js
+++ b/tests/dummy/app/routes/blog/post.js
@@ -4,15 +4,13 @@ export default Route.extend({
   model() {
     return {
       content: '<h1>Overridden post content</h1> <p>This is a post body!</p>',
-      attributes: {
-        author: 'Robert Wagner',
-        authorId: 'rwwagner90',
-        categories: ['ember', 'ember.js'],
-        date: '2018-04-09',
-        slug: 'test-post-slug',
-        title: 'Overridden Title',
-        type: 'article'
-      }
+      author: 'Robert Wagner',
+      authorId: 'rwwagner90',
+      categories: ['ember', 'ember.js'],
+      date: '2018-04-09',
+      slug: 'test-post-slug',
+      title: 'Overridden Title',
+      type: 'article'
     };
   }
 });


### PR DESCRIPTION
This removes the need for the attributes prefix (suffix?) on the model data. Anything that needed to re-introduce that prefix could overload `currentRouteModel` as follows:

```
  currentRouteModel: computed('routeName', function() {
    return getOwner(this).lookup(`route:${this.get('routeName')}`).get('currentModel.attributes');
  }),
```

Fixes #4 