### PR TITLE
Update twitter image meta tag

### DIFF
--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -67,7 +67,7 @@
 {{/if}}
 
 {{#if this.model.imgSrc}}
-  <meta name="twitter:image:src" content={{this.model.imgSrc}}>
+  <meta name="twitter:image" content={{this.model.imgSrc}}>
 {{/if}}
 
 {{#if (or this.model.articleTitle this.model.title)}}


### PR DESCRIPTION
Update the meta tag from `twitter:image:src` to `twitter:image`
Looks like the Twitter docs are all using the latter now (https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary)
> <meta name="twitter:image" content="https://farm6.staticflickr.com/5510/14338202952_93595258ff_z.jpg" />